### PR TITLE
Fix configure-shell-logins

### DIFF
--- a/ansible/roles/common-configure-shell-logins/tasks/main.yml
+++ b/ansible/roles/common-configure-shell-logins/tasks/main.yml
@@ -47,6 +47,7 @@
     dest: "/etc/ssh/sshd_config"
     regexp: "^AllowUsers"
     line: "#AllowUsers {{ ansible_user }}"
+  when: allowed_groups is defined
 
 - name: "Add groups to /etc/ssh/sshd_config AllowGroups: {{ allowed_groups }}"
   lineinfile:
@@ -57,6 +58,7 @@
     #backup: yes
   notify:
     - Restart sshd
+  when: allowed_groups is defined
 
 #  - name: Print user defined variables
 #    debug:

--- a/ansible/roles/common-configure-shell-logins/tasks/main.yml
+++ b/ansible/roles/common-configure-shell-logins/tasks/main.yml
@@ -42,12 +42,16 @@
   notify:
     - Restart sshd
 
+- name: "Raise error if allow_groups is not defined"
+  fail:
+    msg: "variable 'allow_groups' is not defined"
+  when: allowed_groups is not defined
+
 - name: "in /etc/ssh/sshd_config comment out AllowUsers - as over-rides AllowGroups"
   lineinfile:
     dest: "/etc/ssh/sshd_config"
     regexp: "^AllowUsers"
     line: "#AllowUsers {{ ansible_user }}"
-  when: allowed_groups is defined
 
 - name: "Add groups to /etc/ssh/sshd_config AllowGroups: {{ allowed_groups }}"
   lineinfile:
@@ -58,7 +62,6 @@
     #backup: yes
   notify:
     - Restart sshd
-  when: allowed_groups is defined
 
 #  - name: Print user defined variables
 #    debug:

--- a/ansible/roles/common-create-admin-users-logins/vars/users.yml
+++ b/ansible/roles/common-create-admin-users-logins/vars/users.yml
@@ -21,9 +21,9 @@ users:
   - username: "a.bulgaris"
     comment: "Alejandro Bulgaris"
     uid: 34928
-#  - username: "c.hyde"
-#    comment: "Cameron Hyde"
-#    uid: 26717
+  - username: "c.hyde"
+    comment: "Cameron Hyde"
+    uid: 26717
 #  - username: "s.williams"
 #    comment: "Sarah Williams"
 #    uid: 35938
@@ -47,8 +47,8 @@ login_users:
     key: files/m.thang.pub
   - username: "n.rhodes"
     key: files/n.rhodes.pub
-#  - username: "c.hyde"
-#    key: files/c.hyde.pub
+  - username: "c.hyde"
+    key: files/c.hyde.pub
 #  - username: "s.williams"
 #    key: files/s.williams.pub
 #  - username: "c.bromhead"

--- a/ansible/roles/web-admin-users-groups/vars/users.yml
+++ b/ansible/roles/web-admin-users-groups/vars/users.yml
@@ -4,10 +4,10 @@ admin_users:
   - "j.lee"
   - "n.rhodes"
   - "m.thang"
-#  - "c.hyde"
+  - "c.hyde"
 
 # sudo rights on web servers ONLY
 sudo_users:
   - "m.thang"
-#  - "c.hyde"
+  - "c.hyde"
 


### PR DESCRIPTION
- Throw error when `allowed_groups` is undefined
- Add `c.hyde` to admin and web admin users