### PR TITLE
import Nectar terraform definitions

### DIFF
--- a/terraform-nectar/.gitignore
+++ b/terraform-nectar/.gitignore
@@ -1,0 +1,5 @@
+# Ignore Terraform state files within the terraform directory
+*.tfstate
+*.tfstate.*
+.terraform/
+

--- a/terraform-nectar/apollo-varsanddata.tf
+++ b/terraform-nectar/apollo-varsanddata.tf
@@ -1,0 +1,66 @@
+# variables and data common across multiple .tf files
+# or useful to have in one place for reference and ease of use
+# this is the only file that will need regular changes
+
+# WARNING: commenting out or removing an apollo number will result in DELETION of that apollo!!!
+
+locals {
+    # temporary and teaching Apollo instance numbers and creation date: tft_apollo_XXX
+    temporary_apollo_numbers = {
+    #    "005" = "2025MMDD",
+    #    "023" = "2025MMDD",
+        "999" = "20250502"
+    }
+
+    # internal Apollo instance numbers and creation date: tfi_apollo_XXX_YYYYMMDD
+    internal_apollo_numbers = {
+    #    "001" = "2025MMDD",
+    #    "004" = "202505DD",
+        "011" = "20250501"
+    }
+
+    # client Apollo instance numbers and creation date: tfc_apollo_XXX_YYYYMMDD
+    client_apollo_numbers = {
+    #    "012" = "2025MMDD",
+    #    "020" = "2025MMDD",
+    #    "035" = "2025MMDD"
+    }
+
+    # apollos with non-default (4c16r r3.medium) flavor
+    # 2c8r r3.small for testing, 8c32r r3.large for high load, 8c16r m3.medium for compiling
+    # WARNING: changes to flavor will result in VM being recreated
+    apollo_default_flavor = "r3.medium"
+    apollo_flavors = {
+        "011" = "m3.large",
+        #"020" = "r3.large",
+        #"035" = "r3.large",
+        "999" = "r3.small"
+    }
+
+    # security groups required for apollo instances (DO NOT CHANGE UNLESS NEEDED for Grafana for eg)
+    # while some are only required for specific instances,
+    # for managing many apollos, they can all have the additional groups
+    # (ufw will block these if not configured on the apollo instance)
+    apollo_security_groups = [
+        "default",
+        "SSH_access",
+        "Web_Server_access_full",
+        "Postgresql_Server_local_access",
+        "SequenceServer_Web_access",
+        "Apollo3_Server_access",
+        "NRPE_local_access",
+        "ICMP_local_access"
+    ]
+}
+
+
+# the following allows us to look up the OS image by name, which means that
+# we'll always use the latest update of the image when we create a new VM
+# but requires changes to image_id to be ignored in VM with
+#   lifecycle { ignore_changes= [ image_id ] }
+
+data "openstack_images_image_v2" "ubuntu24_image" {
+    name = "NeCTAR Ubuntu 24.04 LTS (Noble) amd64"
+}
+
+

--- a/terraform-nectar/client-apollos-nectar.tf
+++ b/terraform-nectar/client-apollos-nectar.tf
@@ -1,0 +1,52 @@
+# Terraform managed client apollos: tfc_apollo_XXX_YYYYMMDD
+# Note: client_apollo_numbers, apollo_default_flavor and ubuntu24_image are defined in varsanddata.tf
+
+# create a VM for each listed apollo, with names like tfc_apollo_012_20250507
+resource "openstack_compute_instance_v2" "client_apollo_vms" {
+    for_each          = local.client_apollo_numbers
+
+    name              = "tfc_apollo_${each.key}_${each.value}"
+    flavor_name       = lookup(local.apollo_flavors, each.key, local.apollo_default_flavor)
+    key_pair          = "apollo-nectar"
+    availability_zone = "ardc-syd-1"
+    image_id          = data.openstack_images_image_v2.ubuntu24_image.id # lookup the image ID
+
+    network {
+        name =        "apollo-internal-network"  
+    }
+
+    security_groups = local.apollo_security_groups
+
+    metadata = {
+        description = "Terraform managed client Apollo VM"
+    }
+
+    lifecycle {
+        ignore_changes  = [
+            image_id  # Ignore changes to the Ubuntu 24.04 OS image ID if OS image is updated by provider
+        ]
+    }
+}
+
+# for each VM create a floating IP in ardc-syd IP pool
+resource "openstack_networking_floatingip_v2" "client_apollo_fips" {
+    for_each = openstack_compute_instance_v2.client_apollo_vms
+
+    pool = "ardc-syd"  # IP in ardc-syd availability zone IP pool
+}
+
+# fetch the port for each VM instance based on the fixed IP
+data "openstack_networking_port_v2" "client_apollo_ports" {
+    for_each = openstack_compute_instance_v2.client_apollo_vms
+
+    fixed_ip = openstack_compute_instance_v2.client_apollo_vms[each.key].network[0].fixed_ip_v4
+}
+
+# For each VM, attach the floating IP using the VM's port ID
+resource "openstack_networking_floatingip_associate_v2" "client_apollo_fips_associate" {
+    for_each = openstack_networking_floatingip_v2.client_apollo_fips
+
+    floating_ip = each.value.address
+    port_id     = data.openstack_networking_port_v2.client_apollo_ports[each.key].id
+}
+

--- a/terraform-nectar/internal-apollos-nectar.tf
+++ b/terraform-nectar/internal-apollos-nectar.tf
@@ -1,0 +1,69 @@
+# Terraform managed internal apollos: tfi_apollo_XXX_YYYYMMDD
+# Note: internal_apollo_numbers, apollo_default_flavor and ubuntu24_image are defined in varsanddata.tf
+
+# create a VM for each listed apollo, with names like tfi_apollo_011_20250501
+resource "openstack_compute_instance_v2" "internal_apollo_vms" {
+    for_each          = local.internal_apollo_numbers
+
+    name              = "tfi_apollo_${each.key}_${each.value}"
+    flavor_name       = lookup(local.apollo_flavors, each.key, local.apollo_default_flavor)
+    key_pair          = "apollo-nectar"
+    availability_zone = "ardc-syd-1"
+    image_id          = data.openstack_images_image_v2.ubuntu24_image.id # lookup the image ID
+
+    network {
+        name =        "apollo-internal-network"  
+    }
+
+    security_groups = local.apollo_security_groups
+
+    metadata = {
+        description = "Terraform managed internal Apollo VM"
+    }
+
+    lifecycle {
+        ignore_changes  = [
+            image_id  # Ignore changes to the Ubuntu 24.04 OS image ID if OS image is updated by provider
+        ]
+    }
+}
+
+# for each VM create a floating IP in ardc-syd IP pool
+resource "openstack_networking_floatingip_v2" "internal_apollo_fips" {
+    for_each = openstack_compute_instance_v2.internal_apollo_vms
+
+    pool = "ardc-syd"  # IP in ardc-syd availability zone IP pool
+}
+
+# fetch the port for each VM instance based on the fixed IP
+data "openstack_networking_port_v2" "internal_apollo_ports" {
+    for_each = openstack_compute_instance_v2.internal_apollo_vms
+
+    fixed_ip = openstack_compute_instance_v2.internal_apollo_vms[each.key].network[0].fixed_ip_v4
+}
+
+# For each VM, attach the floating IP using the VM's port ID
+resource "openstack_networking_floatingip_associate_v2" "internal_apollo_fips_associate" {
+    for_each = openstack_networking_floatingip_v2.internal_apollo_fips
+
+    floating_ip = each.value.address
+    port_id     = data.openstack_networking_port_v2.internal_apollo_ports[each.key].id
+}
+
+
+# create 100GB volume for apollo builds, to be attached to apollo-011
+resource "openstack_blockstorage_volume_v3" "apollo_build_volume" {
+    name              = "Apollo-Build"
+    size              = 100  # Size of the volume in GB
+    availability_zone = "ardc-syd-1"
+    description       = "100GB volume for apollo-011 instance"
+    depends_on        = [openstack_compute_instance_v2.internal_apollo_vms["011"]]
+}
+
+# attach Apollo-Build volume to apollo-011 instance
+resource "openstack_compute_volume_attach_v2" "apollo_011_volume_attach" {
+    instance_id  = openstack_compute_instance_v2.internal_apollo_vms["011"].id
+    volume_id    = openstack_blockstorage_volume_v3.apollo_build_volume.id
+    device       = "/dev/vdb"  # attach volume to /dev/vdb
+}
+

--- a/terraform-nectar/large-volumes-nectar_not_managed.txt
+++ b/terraform-nectar/large-volumes-nectar_not_managed.txt
@@ -1,0 +1,30 @@
+/*
+# WARNING: backups volume is NOT managed by terraform to prevent accidental deletion!
+# this volume already exists, import with: terraform import openstack_blockstorage_volume_v3.apollo_backups_vol <ID>
+# this block will not be used to create a new volume, it's only needed for referencing and managing the volume's attachment
+resource "openstack_blockstorage_volume_v3" "apollo_backups_vol" {
+    availability_zone = "ardc-syd-1"
+    name              = "Apollo-Backups"
+    size              = 5120
+
+    lifecycle {
+      prevent_destroy = true
+    }
+}
+*/
+
+/*
+# WARNING: user-data volume is NOT managed by terraform to prevent accidental deletion!
+# this volume already exists, import with: terraform import openstack_blockstorage_volume_v3.apollo_user_data_a_vol <ID>
+# this block will not be used to create a new volume, it's only needed for referencing and managing the volume's attachment
+resource "openstack_blockstorage_volume_v3" "apollo_user_data_a_vol" {
+    availability_zone = "ardc-syd-1"
+    name              = "Apollo-User-Data-A"
+    size              = 20480
+
+    lifecycle {
+        prevent_destroy = true
+    }
+}
+*/
+

--- a/terraform-nectar/providers.tf
+++ b/terraform-nectar/providers.tf
@@ -1,0 +1,13 @@
+# Define required providers
+terraform {
+    required_version = ">= 0.14.0"
+    required_providers {
+        openstack = {
+            source  = "terraform-provider-openstack/openstack"
+            version = "~> 1.53.0"
+        }
+    }
+}
+
+provider "openstack" {}
+

--- a/terraform-nectar/readme.terraform.txt
+++ b/terraform-nectar/readme.terraform.txt
@@ -1,0 +1,14 @@
+Terraform files and VM naming scheme
+  - apollo-varsanddata.tf: variables and data for creating apollos
+  - servers-nectar.tf:  tfs_ terraform managed servers - infrastructure only with prevent_destroy
+  - internal-apollos-nectar.tf: tfi_ terraform managed internal apollo/jbrowse sandpits
+  - temporary-apollos-nectar - tft_ terraform managed temp teaching and test apollos - to be recreated often
+  - client-apollos-nectar.tf: tfc_ terraform managed client apollo/jbrowse
+  - secgroups-nectar.tf: security group definitions
+  - providers.tf: terraform openstack provider definition
+  - large-volumes-nectar_not_managed.txt: large volumes not managed by Terraform
+  - test-vm-definition.txt: testing terraform VM definitions - rename extension to use
+
+Note that these are dependent on the internal network apollo-internal-network 192.168.0.*
+being created manually beforehand.
+

--- a/terraform-nectar/secgroups-nectar.tf
+++ b/terraform-nectar/secgroups-nectar.tf
@@ -1,0 +1,290 @@
+# ssh access security group
+resource "openstack_networking_secgroup_v2" "SSH_access" {
+    description = "Allow SSH access"
+    name        = "SSH_access"
+}
+
+# ssh security group rules
+resource "openstack_networking_secgroup_rule_v2" "SSH_access-ingress-tcp-22" {
+    direction         = "ingress"
+    ethertype         = "IPv4"
+    port_range_min    = 22
+    port_range_max    = 22
+    protocol          = "tcp"
+    remote_ip_prefix  = "0.0.0.0/0"
+    security_group_id = openstack_networking_secgroup_v2.SSH_access.id
+}
+
+# web server access security group
+resource "openstack_networking_secgroup_v2" "Web_Server_access_full" {
+    description = "Allow http(s) access on ports 80, 443, 8080"
+    name        = "Web_Server_access_full"
+}
+
+# web server access security group rules
+resource "openstack_networking_secgroup_rule_v2" "Web_Server_access_full-ingress-tcp-80" {
+    direction         = "ingress"
+    ethertype         = "IPv4"
+    port_range_min    = 80
+    port_range_max    = 80
+    protocol          = "tcp"
+    remote_ip_prefix  = "0.0.0.0/0"
+    security_group_id = openstack_networking_secgroup_v2.Web_Server_access_full.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "Web_Server_access_full-ingress-tcp-443" {
+    direction         = "ingress"
+    ethertype         = "IPv4"
+    port_range_min    = 443
+    port_range_max    = 443
+    protocol          = "tcp"
+    remote_ip_prefix  = "0.0.0.0/0"
+    security_group_id = openstack_networking_secgroup_v2.Web_Server_access_full.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "Web_Server_access_full-ingress-tcp-8080" {
+    direction         = "ingress"
+    ethertype         = "IPv4"
+    port_range_min    = 8080
+    port_range_max    = 8080
+    protocol          = "tcp"
+    remote_ip_prefix  = "0.0.0.0/0"
+    security_group_id = openstack_networking_secgroup_v2.Web_Server_access_full.id
+}
+
+# Globus Connect Server data transfer security group
+resource "openstack_networking_secgroup_v2" "Globus_Connect_access" {
+    description = "Globus Connect Server access to ports 50000-51000"
+    name        = "Globus_Connect_access"
+}
+
+# Globus_access security group rules
+resource "openstack_networking_secgroup_rule_v2" "Globus_Connect_access-ingress-tcp-50000_51000" {
+    direction         = "ingress"
+    ethertype         = "IPv4"
+    port_range_min    = 50000
+    port_range_max    = 51000
+    protocol          = "tcp"
+    remote_ip_prefix  = "0.0.0.0/0"
+    security_group_id = openstack_networking_secgroup_v2.Globus_Connect_access.id
+}
+
+# NFS Server security group rules
+resource "openstack_networking_secgroup_v2" "NFS_Server_local_access" {
+    name = "NFS_Server_local_access"
+    description = "NFS Server local access on ports 111, 2049, 50003"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "NFS_Server_local_access-ingress-tcp-111" {
+    direction = "ingress"
+    ethertype = "IPv4"
+    protocol = "tcp"
+    port_range_min = "111"
+    port_range_max = "111"
+    remote_ip_prefix = "192.168.0.0/24"
+    security_group_id = openstack_networking_secgroup_v2.NFS_Server_local_access.id
+} 
+
+resource "openstack_networking_secgroup_rule_v2" "NFS_Server_local_access-ingress-udp-111" {
+    direction = "ingress"
+    ethertype = "IPv4"
+    protocol = "udp"
+    port_range_min = "111"
+    port_range_max = "111"
+    remote_ip_prefix = "192.168.0.0/24"
+    security_group_id = openstack_networking_secgroup_v2.NFS_Server_local_access.id
+} 
+
+resource "openstack_networking_secgroup_rule_v2" "NFS_Server_local_access-ingress-tcp-2049" {
+    direction = "ingress"
+    ethertype = "IPv4"
+    protocol = "tcp"
+    port_range_min = "2049"
+    port_range_max = "2049"
+    remote_ip_prefix = "192.168.0.0/24"
+    security_group_id = openstack_networking_secgroup_v2.NFS_Server_local_access.id
+} 
+
+resource "openstack_networking_secgroup_rule_v2" "NFS_Server_local_access-ingress-tcp-50003" {
+    direction = "ingress"
+    ethertype = "IPv4"
+    protocol = "tcp"
+    port_range_min = "50003"
+    port_range_max = "50003"
+    remote_ip_prefix = "192.168.0.0/24"
+    security_group_id = openstack_networking_secgroup_v2.NFS_Server_local_access.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "NFS_Server_local_access-ingress-udp-50003" {
+    direction = "ingress"
+    ethertype = "IPv4"
+    protocol = "udp"
+    port_range_min = "50003"
+    port_range_max = "50003"
+    remote_ip_prefix = "192.168.0.0/24"
+    security_group_id = openstack_networking_secgroup_v2.NFS_Server_local_access.id
+}
+
+# PostgreSQL Server security group rules
+resource "openstack_networking_secgroup_v2" "Postgresql_Server_local_access" {
+    name = "Postgresql_Server_local_access"
+    description = "Postgresql server local access on port 5432"
+}
+  
+resource "openstack_networking_secgroup_rule_v2" "Postgresql_Server_local_access-ingress-tcp-5432" {
+    direction = "ingress"
+    ethertype = "IPv4"
+    protocol = "tcp" 
+    port_range_min = "5432"
+    port_range_max = "5432"
+    remote_ip_prefix = "192.168.0.0/24"
+    security_group_id = openstack_networking_secgroup_v2.Postgresql_Server_local_access.id
+}
+
+# ICMP (ping) security group rules
+resource "openstack_networking_secgroup_v2" "ICMP_local_access" {
+    name = "ICMP_local_access"
+    description = "Allow ICMP (ping) from local network"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "ICMP_local_access-ingress-icmp-Any" {
+    direction = "ingress"
+    ethertype = "IPv4"
+    protocol = "icmp"
+    remote_ip_prefix = "192.168.0.0/24"
+    security_group_id = openstack_networking_secgroup_v2.ICMP_local_access.id
+}
+
+# SequenceServer security group rules
+resource "openstack_networking_secgroup_v2" "SequenceServer_Web_access" {
+    name = "SequenceServer_Web_access"
+    description = "SequenceServer web access on port 4567"
+} 
+
+resource "openstack_networking_secgroup_rule_v2" "SequenceServer_Web_access-ingress-tcp-4567" {
+    direction = "ingress"
+    ethertype = "IPv4"
+    protocol = "tcp"
+    port_range_min = "4567"
+    port_range_max = "4567"
+    remote_ip_prefix = "0.0.0.0/0"
+    security_group_id = openstack_networking_secgroup_v2.SequenceServer_Web_access.id
+}
+
+# Apollo3 security group rules
+resource "openstack_networking_secgroup_v2" "Apollo3_Server_access" {
+    name = "Apollo3_Server_access"
+    description = "Allow connections to Apollo3 Server and plugins on ports 3999 and 9000"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "Apollo3_Server_access-ingress-tcp-3999" {
+    direction = "ingress"
+    ethertype = "IPv4"
+    protocol = "tcp"
+    port_range_min = "3999"
+    port_range_max = "3999"
+    remote_ip_prefix = "0.0.0.0/0"
+    security_group_id = openstack_networking_secgroup_v2.Apollo3_Server_access.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "Apollo3_Server_access-ingress-tcp-9000" {
+    direction = "ingress"
+    ethertype = "IPv4"
+    protocol = "tcp"
+    port_range_min = "9000"
+    port_range_max = "9000"
+    remote_ip_prefix = "0.0.0.0/0"
+    security_group_id = openstack_networking_secgroup_v2.Apollo3_Server_access.id
+}
+
+# NRPE (Nagios) security group rules
+resource "openstack_networking_secgroup_v2" "NRPE_local_access" {
+    name = "NRPE_local_access"
+    description = "Allow local NRPE connections from Nagios on port 5666"
+} 
+
+resource "openstack_networking_secgroup_rule_v2" "NRPE_local_access-ingress-tcp-5666" {
+    direction = "ingress"
+    ethertype = "IPv4"
+    protocol = "tcp"
+    port_range_min = "5666"
+    port_range_max = "5666"
+    remote_ip_prefix = "192.168.0.0/24"
+    security_group_id = openstack_networking_secgroup_v2.NRPE_local_access.id
+}
+
+# Prometheus server (Grafana) security group rules
+resource "openstack_networking_secgroup_v2" "Prometheus_Server_local_access" {
+    name = "Prometheus_Server_local_access"
+    description = "Allow local Prometheus connections on port 9090"
+}
+
+# Rule for general Prometheus connections
+resource "openstack_networking_secgroup_rule_v2" "Prometheus_Server_local_access-ingress-tcp-9090" {
+    direction = "ingress"
+    ethertype = "IPv4"
+    protocol = "tcp"
+    port_range_min = "9090"
+    port_range_max = "9090"
+    remote_ip_prefix = "192.168.0.0/24"
+    security_group_id = openstack_networking_secgroup_v2.Prometheus_Server_local_access.id
+}
+
+/*** TODO: define this ONLY if it is used
+# rule for Prometheus Node Exporter
+resource "openstack_networking_secgroup_rule_v2" "Prometheus_Server_local_access-node_exporter-ingress-tcp-9100" {
+    direction = "ingress"
+    ethertype = "IPv4"
+    protocol = "tcp"
+    port_range_min = "9100"
+    port_range_max = "9100"
+    remote_ip_prefix = "192.168.0.0/24"
+    security_group_id = openstack_networking_secgroup_v2.Prometheus_Server_local_access.id
+}
+***/
+
+/*** TODO: define this ONLY if it is used
+# rule for Prometheus Postgres Exporter
+resource "openstack_networking_secgroup_rule_v2" "Prometheus_Server_local_access-postgres_exporter-ingress-tcp-9187" {
+    direction = "ingress"
+    ethertype = "IPv4"
+    protocol = "tcp"
+    port_range_min = "9187"
+    port_range_max = "9187"
+    remote_ip_prefix = "192.168.0.0/24"
+    security_group_id = openstack_networking_secgroup_v2.Prometheus_Server_local_access.id
+}
+***/
+
+# Prometheus Web access security group rules
+resource "openstack_networking_secgroup_v2" "Prometheus_Server_Web_access" {
+    name = "Prometheus_Server_Web_access"
+    description = "Prometheus Server Web UI access on port 9090"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "Prometheus_Server_Web_access-ingress-tcp-9090" {
+    direction = "ingress"
+    ethertype = "IPv4"
+    protocol = "tcp"
+    port_range_min = "9090"
+    port_range_max = "9090"
+    remote_ip_prefix = "0.0.0.0/0"
+    security_group_id = openstack_networking_secgroup_v2.Prometheus_Server_Web_access.id
+}
+
+# Grafana Web access security group rules
+resource "openstack_networking_secgroup_v2" "Grafana_Server_Web_access" {
+    name = "Grafana_Server_Web_access"
+    description = "Grafana Server Web UI access on port 3000"
+} 
+
+resource "openstack_networking_secgroup_rule_v2" "Grafana_Server_Web_access-ingress-tcp-3000" {
+    direction = "ingress"
+    ethertype = "IPv4"
+    protocol = "tcp"
+    port_range_min = "3000"
+    port_range_max = "3000"
+    remote_ip_prefix = "0.0.0.0/0"
+    security_group_id = openstack_networking_secgroup_v2.Grafana_Server_Web_access.id
+} 
+

--- a/terraform-nectar/servers-nectar.tf
+++ b/terraform-nectar/servers-nectar.tf
@@ -1,0 +1,73 @@
+# Terraform managed servers: tfs_apollo_NAME_YYYYMMDD
+
+# backup/deploy server VM
+resource "openstack_compute_instance_v2" "tfs_apollo_backup_20250430" {
+    name              = "tfs_apollo_backup_20250430"
+    flavor_name       = "m3.large"
+    key_pair          = "apollo-nectar"
+    availability_zone = "ardc-syd-1"
+
+    block_device {          # define boot volume with custom size
+        uuid                  = "49f677df-01e5-45c9-9611-609ef21f60e1" # NeCTAR Ubuntu 24.04 LTS (Noble) amd64
+        source_type           = "image"
+        volume_size           = 50
+        boot_index            = 0
+        destination_type      = "volume"
+        delete_on_termination = true
+    }
+
+    network {
+        name =        "apollo-internal-network"  
+    }
+
+    security_groups = [
+        "default",
+        "SSH_access",
+        "NRPE_local_access",
+        "ICMP_local_access"
+    ]
+
+    metadata = {
+        description = "Backup server for Apollo project"
+    }
+
+    lifecycle {
+        prevent_destroy = true
+    }
+}
+
+# create floating IP in ardc-syd IP pool
+resource "openstack_networking_floatingip_v2" "apollo_backup_fip" {
+    pool = "ardc-syd"  # IP in ardc-syd availability zone IP pool
+}
+
+# fetch the port for VM instance based on the fixed IP
+data "openstack_networking_port_v2" "apollo_backup_port" {
+    fixed_ip = openstack_compute_instance_v2.tfs_apollo_backup_20250430.network[0].fixed_ip_v4
+}
+
+# attach floating IP using the VM port ID
+resource "openstack_networking_floatingip_associate_v2" "apollo_backup_fip_assoc" {
+    floating_ip = openstack_networking_floatingip_v2.apollo_backup_fip.address
+    port_id     = data.openstack_networking_port_v2.apollo_backup_port.id
+}
+
+/*
+# attach IP to VM (deprecated method - for reference)
+resource "openstack_compute_floatingip_associate_v2" "apollo_backup_fip_assoc" {
+    depends_on  = [openstack_compute_instance_v2.tfs_apollo_backup_20250430]
+    floating_ip = openstack_networking_floatingip_v2.apollo_backup_fip.address
+    instance_id = openstack_compute_instance_v2.tfs_apollo_backup_20250430.id
+}
+*/
+
+/*
+# WARNING: volume is NOT managed by terraform to prevent accidental deletion! manual attachment required!
+# attach backups volume to VM
+resource "openstack_compute_volume_attach_v2" "apollo_backups_vol" {
+    instance_id       = openstack_compute_instance_v2.tfs_apollo_backup_20250430.id
+    volume_id         = openstack_blockstorage_volume_v3.apollo_backups_vol.id
+    device	      = "/dev/vdb"
+}
+*/
+

--- a/terraform-nectar/temporary-apollos-nectar.tf
+++ b/terraform-nectar/temporary-apollos-nectar.tf
@@ -1,0 +1,66 @@
+# Terraform managed temporary apollos for testing or teaching: tft_apollo_XXX
+# Note: internal_apollo_numbers, apollo_default_flavor and ubuntu24_image are defined in varsanddata.tf
+
+# create a VM for each listed apollo, with names like tft_apollo_999
+# note that date is relegated to metadata so that terraform can re-attach the same floating IP
+# and these VMs get rebuilt frequently
+resource "openstack_compute_instance_v2" "temporary_apollo_vms" {
+    for_each          = local.temporary_apollo_numbers
+
+    name              = "tft_apollo_${each.key}"
+    #flavor_name       = each.key == "999" ? "r3.small" : "r3.medium"  # 2c8r or 4c16r
+    flavor_name       = lookup(local.apollo_flavors, each.key, local.apollo_default_flavor)
+    key_pair          = "apollo-nectar"
+    availability_zone = "ardc-syd-1"
+    image_id          = data.openstack_images_image_v2.ubuntu24_image.id # lookup the image ID
+
+    network {
+        name =        "apollo-internal-network"  
+    }
+
+    security_groups = local.apollo_security_groups
+
+    metadata = {
+        description   = "Terraform managed temporary Apollo VM"
+        creation_date = "${each.value}"
+    }
+
+    # ensure floating IP will not be destroyed with the VM
+    lifecycle {
+        create_before_destroy = true
+        ignore_changes  = [
+            image_id  # Ignore changes to the Ubuntu 24.04 OS image ID if OS image is updated by provider
+        ]
+    }
+}
+
+# for each VM create a floating IP in ardc-syd IP pool
+resource "openstack_networking_floatingip_v2" "temporary_apollo_fips" {
+    for_each = openstack_compute_instance_v2.temporary_apollo_vms
+    pool = "ardc-syd"  # IP in ardc-syd availability zone IP pool
+
+    # prevent the floating IP from being destroyed when the VM is destroyed
+    lifecycle {
+        prevent_destroy = true
+    }
+}
+
+# fetch the port for each VM instance based on the fixed IP
+data "openstack_networking_port_v2" "temporary_apollo_ports" {
+    for_each = openstack_compute_instance_v2.temporary_apollo_vms
+    fixed_ip = openstack_compute_instance_v2.temporary_apollo_vms[each.key].network[0].fixed_ip_v4
+}
+
+# for each VM, attach the floating IP using the VM's port ID
+resource "openstack_networking_floatingip_associate_v2" "temporary_apollo_fips_associate" {
+    for_each = openstack_networking_floatingip_v2.temporary_apollo_fips
+
+    floating_ip = each.value.address
+    port_id     = data.openstack_networking_port_v2.temporary_apollo_ports[each.key].id
+
+    # ensure that the floating IP is reassociated with the new VM when the VM is recreated
+    lifecycle {
+        create_before_destroy = true
+    }
+}
+

--- a/terraform-nectar/test-vm-definition.txt
+++ b/terraform-nectar/test-vm-definition.txt
@@ -1,0 +1,68 @@
+
+# test VM 
+resource "openstack_compute_instance_v2" "apollo_test" {
+  name              = "apollo_test"
+  flavor_name       = "m3.xsmall"
+  key_pair          = "apollo-nectar"
+  availability_zone = "ardc-syd-1"
+
+  block_device {          # define boot volume with custom size
+    uuid                  = "49f677df-01e5-45c9-9611-609ef21f60e1" # NeCTAR Ubuntu 24.04 LTS (Noble) amd64
+    source_type           = "image"
+    volume_size           = 50
+    boot_index            = 0
+    destination_type      = "volume"
+    delete_on_termination = true
+  }
+
+  network {
+    name =        "apollo-internal-network"  
+  }
+
+  security_groups = [
+    "default",
+    "SSH_access",
+    "NRPE_local_access",
+    "ICMP_local_access"
+  ]
+}
+
+# floating IP in ardc-syd IP pool
+resource "openstack_networking_floatingip_v2" "apollo_test_fip" {
+  pool = "ardc-syd"  # IP in ardc-syd availability zone IP pool
+}
+
+# Fetch the port for VM instance based on the fixed IP
+data "openstack_networking_port_v2" "apollo_test_port" {
+    fixed_ip = openstack_compute_instance_v2.apollo_test.network[0].fixed_ip_v4
+}
+
+# attach the created floating IP using the port ID
+resource "openstack_networking_floatingip_associate_v2" "apollo_test_fips_associate" {
+    floating_ip = openstack_networking_floatingip_v2.apollo_test_fip.address
+    port_id     = data.openstack_networking_port_v2.apollo_test_port.id
+}
+
+/*
+# attach IP to VM (deprecated method)
+resource "openstack_compute_floatingip_associate_v2" "apollo_test_floating_ip_assoc" {
+  floating_ip = openstack_networking_floatingip_v2.apollo_test_floating_ip.address
+  instance_id = openstack_compute_instance_v2.apollo_test.id
+}
+*/
+
+/*
+# 100G test volume
+resource "openstack_blockstorage_volume_v3" "test_vol" {
+    availability_zone = "ardc-syd-1"
+    name              = "test-vol"
+    size              = 100
+}
+
+# attach volume to VM
+resource "openstack_compute_volume_attach_v2" "test_vol" {
+  instance_id       = openstack_compute_instance_v2.apollo_test.id
+  volume_id         = openstack_blockstorage_volume_v3.test_vol.id
+  #device	    = "/dev/vdb"
+}
+*/


### PR DESCRIPTION
Terraform definitions for Apollo VMs in Nectar tenancy. Note this DOES NOT include terraform state files which should not be stored on github, hence the inclusion of a .gitignore.
