### PR TITLE
use referential network security group for Postgres

### DIFF
--- a/terraform-nectar/servers-nectar.tf
+++ b/terraform-nectar/servers-nectar.tf
@@ -24,7 +24,8 @@ resource "openstack_compute_instance_v2" "tfs_apollo_backup_20250430" {
         "default",
         "SSH_access",
         "NRPE_local_access",
-        "ICMP_local_access"
+        "ICMP_local_access",
+        "Postgresql_allowed_group"
     ]
 
     metadata = {


### PR DESCRIPTION
For additional security, rather than allowing postgres connections from any VM on the local network (`remote_ip_prefix = "192.168.0.0/24"`), limit connections to apollo-backup, using a referential security group with `remote_group_id`.