### PR TITLE
configure UFW and quotarpc on NFS server

### DIFF
--- a/ansible/roles/nfs-install-server/tasks/main.yml
+++ b/ansible/roles/nfs-install-server/tasks/main.yml
@@ -12,6 +12,23 @@
     enabled: true
     state: started
 
+- name: Allow NFS port (2049) from 192.168.0.0/24 (TCP)
+  ufw:
+    rule: allow
+    port: '2049'
+    proto: tcp
+    src: '192.168.0.0/24'
+
+- name: Allow RPCBind port (111) from 192.168.0.0/24 (UDP/TCP)
+  ufw:
+    rule: allow
+    port: '111'
+    proto: "{{ item }}"
+    src: '192.168.0.0/24'
+  with_items:
+    - 'udp'
+    - 'tcp'
+
 - name: Create the mount point directory for bind mount
   file:
     path: "{{ export_root }}"

--- a/ansible/roles/nfs-server-install-quotas/tasks/main.yml
+++ b/ansible/roles/nfs-server-install-quotas/tasks/main.yml
@@ -16,6 +16,24 @@
     - 'udp'
     - 'tcp'
 
+- name: Enable quotarpc service which runs rpc.rquotad
+  systemd:
+    name: "quotarpc"
+    state: "started"
+    enabled: yes
+
+- name: Configure quotarpc/rpc.rquotad to listen on port 50003
+  lineinfile:
+    path: /etc/default/quota
+    regexp: '^RPCRQUOTADOPTS='
+    line: 'RPCRQUOTADOPTS="-p 50003"'
+    state: present
+
+- name: "Start/Restart quotarpc service with updated config"
+  systemd:
+    name: "quotarpc"
+    state: "restarted"
+
 # ref: https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html/managing_file_systems/limiting-storage-space-usage-on-ext4-with-quotas_managing-file-systems
 - name: enable the ext4 quota feature on device specified by LABEL (external quota files on ext4 are deprecated)
   block:

--- a/ansible/roles/nfs-server-install-quotas/tasks/main.yml
+++ b/ansible/roles/nfs-server-install-quotas/tasks/main.yml
@@ -6,6 +6,16 @@
       - quotatool
     state: present
 
+- name: Allow RQUOTAD port (50003) from 192.168.0.0/24 (UDP/TCP)
+  ufw:
+    rule: allow
+    port: '50003'
+    proto: "{{ item }}"
+    src: '192.168.0.0/24'
+  with_items:
+    - 'udp'
+    - 'tcp'
+
 # ref: https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html/managing_file_systems/limiting-storage-space-usage-on-ext4-with-quotas_managing-file-systems
 - name: enable the ext4 quota feature on device specified by LABEL (external quota files on ext4 are deprecated)
   block:

--- a/ansible/roles/nfs-server-install-quotas/tasks/main.yml
+++ b/ansible/roles/nfs-server-install-quotas/tasks/main.yml
@@ -16,12 +16,6 @@
     - 'udp'
     - 'tcp'
 
-- name: Enable quotarpc service which runs rpc.rquotad
-  systemd:
-    name: "quotarpc"
-    state: "started"
-    enabled: yes
-
 - name: Configure quotarpc/rpc.rquotad to listen on port 50003
   lineinfile:
     path: /etc/default/quota
@@ -29,10 +23,24 @@
     line: 'RPCRQUOTADOPTS="-p 50003"'
     state: present
 
-- name: "Start/Restart quotarpc service with updated config"
+# note: 'state: started' doesn't restart the service if it's already running,
+#       this means if quotarpc is already running the the configuration won't be reflected yet.
+#       unfortunately, ansible seems to be unable to successfully start quotarpc,
+#       so not using 'restarted' to prevent killing an already running quotarpc service.
+- name: Enable and start the quotarpc service with new configuration. This runs rpc.rquotad.
   systemd:
-    name: "quotarpc"
-    state: "restarted"
+    name: quotarpc
+    state: started
+    enabled: yes
+  become: yes
+
+- name: "WARNING: quotarpc may fail to start properly from ansible. Manual intervention may be needed:"
+  debug:
+    msg: "Please run the following commands manually as required:\n\n  sudo systemctl status quotarpc\n  sudo systemctl start quotarpc\n  sudo systemctl status quotarpc\nCGroup should show /usr/sbin/rpc.rquotad -p 50003\n\n"
+
+- name: Wait for a few seconds to read warning above
+  pause:
+    seconds: 5
 
 # ref: https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html/managing_file_systems/limiting-storage-space-usage-on-ext4-with-quotas_managing-file-systems
 - name: enable the ext4 quota feature on device specified by LABEL (external quota files on ext4 are deprecated)


### PR DESCRIPTION
UFW: access from local network 192.168.0.0/24 to ports 2049 (nfs) 111 (rcpbind) 50003 (rquotad)
Configure, start and enable quotarpc service which runs rpc.rquotad.
