### PR TITLE
fix playbook-monitor-refresh-prometheus-sources.yml to run monitor-configure-grafana-dashboards

### DIFF
--- a/ansible/playbooks/playbook-monitor-refresh-sources-and-dashboards.yml
+++ b/ansible/playbooks/playbook-monitor-refresh-sources-and-dashboards.yml
@@ -15,5 +15,5 @@
         name: monitor-refresh-prometheus-sources
     - name: Provision Grafana dashboards from discovered Prometheus targets
       include_role:
-        name: monitor-refresh-prometheus-sources
+        name: monitor-configure-grafana-dashboards
 


### PR DESCRIPTION
Accidentally called monitor-refresh-prometheus-sources role twice