### PR TITLE
create inventory, playbook and docker compose role to setup apollo3-sandpit

### DIFF
--- a/ansible/playbooks/buildapollo3sandpit.inventory
+++ b/ansible/playbooks/buildapollo3sandpit.inventory
@@ -1,0 +1,32 @@
+[newapollovms]
+apollo-001.genome.edu.au ansible_host=apollo-001 target_environment=prod apollo_instance_number=001 apollo_subdomain_name=apollo3-sandpit allowed_groups="ubuntu apollo_admin backup_user apollo3-sandpit_user" apollo_root_disk_device=/dev/vda2 docker_users="['ubuntu', 'j.lee', 'apollo3-sandpit_user']"
+
+[changeipvms]
+apollo-backup.genome.edu.au ansible_user=ubuntu admin_group=sudo
+apollo-user-nfs.genome.edu.au ansible_user=ubuntu admin_group=sudo
+apollo-monitor.genome.edu.au ansible_user=ubuntu admin_group=sudo
+
+[changeipvms:vars]
+hostname_for_ip=apollo-001
+private_ip=192.168.0.116
+
+[nfsservervms]
+apollo-user-nfs.genome.edu.au
+
+[nfsservervms:vars]
+apollo_instance_number=001
+
+[monitorservervms]
+apollo-monitor.genome.edu.au
+
+[monitorservervms:vars]
+apollo_instance_number=001
+private_ip=192.168.0.116
+apollo_root_disk_device=/dev/vda2
+
+[backupservervms]
+apollo-backup.genome.edu.au
+
+[backupservervms:vars]
+apollo_instance_number=001
+

--- a/ansible/playbooks/buildapollo3sandpit.inventory
+++ b/ansible/playbooks/buildapollo3sandpit.inventory
@@ -15,6 +15,7 @@ apollo-user-nfs.genome.edu.au
 
 [nfsservervms:vars]
 apollo_instance_number=001
+nfs_apollo_user_gid=apollo_admin
 
 [monitorservervms]
 apollo-monitor.genome.edu.au

--- a/ansible/playbooks/playbook-jbrowse-discover-exports-and-mount.yml
+++ b/ansible/playbooks/playbook-jbrowse-discover-exports-and-mount.yml
@@ -8,8 +8,8 @@
     etc_exports: /etc/exports # this will be overriden when running with target_environment=test
     jbrowse_export_root: /srv/export/data/nectar
     nfs_client_hostname: "{{ nfs_client }}"
-    portal_user_name: "jbrowse-portal_user"
-    portal_user_id: 15001
+    portal_user_id: 16001
+    portal_user_name: "apollo{{ portal_user_id }}_user" # consistent with apollo/jbrowse usage
 
   tasks:
     - name: Override etc_exports path if in test environment
@@ -89,8 +89,8 @@
 
   vars:
     nfs_server_hostname: "{{ nfs_hostname }}"
-    portal_user_name: "jbrowse-portal_user"
-    portal_user_id: 15001
+    portal_user_name: "jbrowse-portal_user" # local name
+    portal_user_id: 16001 # for jbrowse-001 dataset on NFS server
 
   tasks:
     # now done in common-configure-shell-logins

--- a/ansible/playbooks/playbook-jbrowse-discover-exports-and-mount.yml
+++ b/ansible/playbooks/playbook-jbrowse-discover-exports-and-mount.yml
@@ -9,7 +9,7 @@
     jbrowse_export_root: /srv/export/data/nectar
     nfs_client_hostname: "{{ nfs_client }}"
     portal_user_name: "jbrowse-portal_user"
-    portal_user_id: 16001
+    portal_user_id: 15001
 
   tasks:
     - name: Override etc_exports path if in test environment
@@ -90,7 +90,7 @@
   vars:
     nfs_server_hostname: "{{ nfs_hostname }}"
     portal_user_name: "jbrowse-portal_user"
-    portal_user_id: 16001
+    portal_user_id: 15001
 
   tasks:
     # now done in common-configure-shell-logins

--- a/ansible/playbooks/playbook-setup-nectar-apollo3sandpit.yml
+++ b/ansible/playbooks/playbook-setup-nectar-apollo3sandpit.yml
@@ -1,0 +1,56 @@
+---
+- hosts: all
+  remote_user: ubuntu
+  become: yes
+  become_method: sudo
+  connection: "ssh"
+
+  # The roles to be run by this playbook will be applied to the specified servers
+  # with, for example
+  #   --limit apollo-sandpit.genome.edu.au
+  tasks:
+    - import_role:
+        name: apollo-decode-extravars-setfacts-combined
+    - import_role:
+        name: common-conf-hostname-tz
+    - import_role:
+        name: common-conf-update_etc_hosts
+    - import_role:
+        name: common-add-admin-keys
+    - import_role:
+        name: common-configure-shell-logins
+    - import_role:
+        name: common-create-admin-users-logins
+    - import_role:
+        name: common-install-fail2ban
+    - import_role:
+        name: common-configure-ufw
+    - import_role:
+        name: common-nagios-nrpe
+    - import_role:
+        name: common-prometheus-node-exporter-ubuntu
+    - import_role:
+        name: common-install-utils
+    - import_role: 
+        # Use snapd to install certbot in Ubuntu >= 20.04
+        name: common-certbot-snapd
+    - import_role:
+        name: common-nginx
+    - import_role:
+        name: apollo-create-cli-user
+    #- import_role: # no additional users need sudo account
+    #    name: web-admin-users-groups
+    - import_role:
+        name: apollo-add-nfs-mount-to-fstab
+    - import_role:
+        name: apollo-certbot-create-cert
+    - import_role:
+        name: apollo-certbot-add-domain
+    # don't use the apollo 2.x nginx config for apollo3
+    #- import_role:
+    #    name: apollo-nginx-set-conf
+    #- import_role:
+    #    name: common-nginx-add-domain
+    - import_role:
+        name: common-install-docker-compose
+

--- a/ansible/roles/common-install-docker-compose/defaults/main.yml
+++ b/ansible/roles/common-install-docker-compose/defaults/main.yml
@@ -1,0 +1,6 @@
+docker_install_compose_plugin: true
+docker_compose_package: docker-compose-plugin
+docker_compose_package_state: present
+docker_users:
+  - ubuntu
+

--- a/ansible/roles/common-install-docker-compose/tasks/main.yml
+++ b/ansible/roles/common-install-docker-compose/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+# Remove old conflicting Docker sources
+- name: Ensure Docker-related APT sources are absent
+  file:
+    path: "{{ item }}"
+    state: absent
+    force: yes
+  with_fileglob:
+    - /etc/apt/sources.list.d/docker*
+
+# Install Docker using geerlingguy.docker
+- name: Include geerlingguy.docker role
+  import_role:
+    name: geerlingguy.docker
+
+# Optionally install the Docker Compose plugin
+- name: Ensure docker-compose plugin is installed (if enabled)
+  apt:
+    name: "{{ docker_compose_package }}"
+    state: "{{ docker_compose_package_state }}"
+  when: docker_install_compose_plugin
+
+# Ensure docker group membership
+- name: Add users to the docker group
+  user:
+    name: "{{ item }}"
+    groups: docker
+    append: yes
+  loop: "{{ docker_users }}"
+

--- a/ansible/roles/common-install-utils/vars/util_packages.yml
+++ b/ansible/roles/common-install-utils/vars/util_packages.yml
@@ -29,4 +29,4 @@ util_packages:
     - duf
     - xkcdpass
     - python3-passlib
-
+    - jq


### PR DESCRIPTION
Also add jq to installed utilities and name jbrowse-001 dataset owner on apollo-user-nfs consistently with apollo/jbrowse usage to apollo001_user to allow apollo-001 to own apollo-001 dataset with 16001 UID.