### PR TITLE
deprecate common-install-nodejs-yarn - wrong yarn and role not fit for purpose (installing Apollo3 CLI tools)

### DIFF
--- a/ansible/playbooks/playbook-setup-nectar-apollo3sandpit.yml
+++ b/ansible/playbooks/playbook-setup-nectar-apollo3sandpit.yml
@@ -53,6 +53,4 @@
     #    name: common-nginx-add-domain
     - import_role:
         name: common-install-docker-compose
-    - import_role:
-        name: common-install-nodejs-yarn
 

--- a/ansible/roles/common-install-nodejs-yarn/tasks/main.yml
+++ b/ansible/roles/common-install-nodejs-yarn/tasks/main.yml
@@ -1,9 +1,0 @@
----
-- name: Install Node.js and Yarn package manager from ubuntu repositories
-  apt:
-    name:
-      - nodejs
-      - yarn
-    state: present
-    update_cache: yes
-


### PR DESCRIPTION
The apt package `yarn` is the cmdtest version of yarn, which is not the JavaScript package manager from the Yarn project.

Need to use Corepack to install Yarn 3.x if using Node.js v16.10. This will be a local (home directory) install.

As the Apollo3 documentation appears to use Yarn v1 and given all the version dependency issues, this role is not fit for purpose - that being to install the Apollo3 CLI tools. Better to stick with Docker container versions.