### PR TITLE
remove grafana legacy apt repo and key and add new repo and key

### DIFF
--- a/ansible/roles/monitor-install-grafana-nginx/defaults/main.yml
+++ b/ansible/roles/monitor-install-grafana-nginx/defaults/main.yml
@@ -2,6 +2,10 @@
 grafana_admin_password: "{{ vault_grafana_password }}"
 grafana_domain: "grafana.genome.edu.au"
 certbot_renew_email: "apollo-ops@biocommons.org.au"
-grafana_repo_key_url: "https://packages.grafana.com/gpg.key"
-grafana_repo: "deb https://packages.grafana.com/oss/deb stable main"
+grafana_repo_url: "https://apt.grafana.com"
+grafana_repo_components: "stable main"
+grafana_key_url: "https://apt.grafana.com/gpg.key"
+grafana_keyring_path: "/etc/apt/keyrings/grafana.gpg"
+grafana_legacy_repo: "deb https://packages.grafana.com/oss/deb stable main"
+grafana_legacy_key: "B53AE77BADB630A683046005963FA27710458545" # Grafana Labs <engineering@grafana.com>
 

--- a/ansible/roles/monitor-install-grafana-nginx/tasks/main.yml
+++ b/ansible/roles/monitor-install-grafana-nginx/tasks/main.yml
@@ -5,22 +5,61 @@
       - apt-transport-https
       - software-properties-common
       - curl
-      - gnupg
+      - gnupg # needed for dearmor of grafana apt keyring
       - prometheus
     state: present
     update_cache: yes
 
-- name: Add Grafana APT key
-  apt_key:
-    url: "{{ grafana_repo_key_url }}"
-    state: present
+- name: Grafana APT keyring + repo setup
+  tags: [grafana_keyring]
+  block:
+  - name: Ensure APT keyrings directory exists
+    file:
+      path: "{{ grafana_keyring_path | dirname }}"
+      state: directory
+      mode: "0755"
 
-- name: Add Grafana APT repository
-  apt_repository:
-    repo: "{{ grafana_repo }}"
-    filename: "grafana"
-    state: present
-    update_cache: yes
+  - name: Download Grafana ASCII-armored GPG key
+    get_url:
+      url: "{{ grafana_key_url }}"
+      dest: "{{ grafana_keyring_path }}.asc"
+      mode: "0644"
+    register: grafana_key_ascii
+
+  - name: Convert Grafana key to dearmored keyring
+    ansible.builtin.command:
+      cmd: "gpg --dearmor -o {{ grafana_keyring_path }} {{ grafana_keyring_path }}.asc"
+    when: grafana_key_ascii is changed or not (grafana_keyring_path is exists)
+    register: grafana_keyring_cmd
+    changed_when: grafana_keyring_cmd.rc == 0
+
+  - name: Set keyring permissions for APT
+    file:
+      path: "{{ grafana_keyring_path }}"
+      mode: "0644"
+
+  # Remove the old repo line if it exists (packages.grafana.com without signed-by)
+  - name: Remove legacy Grafana repo entry
+    apt_repository:
+      repo: "{{ grafana_legacy_repo }}"
+      filename: "grafana"
+      state: absent
+    register: removed_legacy_repo
+
+  - name: Add Grafana APT repository (new style)
+    apt_repository:
+      repo: "deb [signed-by={{ grafana_keyring_path }}] {{ grafana_repo_url }} {{ grafana_repo_components }}"
+      filename: "grafana"
+      state: present
+      update_cache: yes
+
+  # clean up legacy global key to silence warnings
+  - name: Remove expired legacy Grafana key from trusted.gpg (ignore if absent)
+    command:
+      cmd: "gpg --batch --yes --no-default-keyring --keyring /etc/apt/trusted.gpg --delete-key {{ grafana_legacy_key }}"
+    register: _remove_legacy_key
+    changed_when: "'not found' not in (_remove_legacy_key.stderr | default(''))"
+    failed_when: false
 
 - name: Install Grafana
   apt:


### PR DESCRIPTION
Fixes `apt update` failing on apollo-monitor with
```
Err:5 https://packages.grafana.com/oss/deb stable InRelease
  The following signatures were invalid: EXPKEYSIG 963FA27710458545 Grafana Labs <engineering@grafana.com>
    :
W: https://packages.grafana.com/oss/deb/dists/stable/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: https://packages.grafana.com/oss/deb stable InRelease: The following signatures were invalid: EXPKEYSIG 963FA27710458545 Grafana Labs <engineering@grafana.com>
W: Failed to fetch https://packages.grafana.com/oss/deb/dists/stable/InRelease  The following signatures were invalid: EXPKEYSIG 963FA27710458545 Grafana Labs <engineering@grafana.com>
W: Some index files failed to download. They have been ignored, or old ones used instead.
```